### PR TITLE
S3 Bucket Caching

### DIFF
--- a/S3Proxy/cache.go
+++ b/S3Proxy/cache.go
@@ -1,0 +1,30 @@
+package S3Proxy
+
+import "time"
+
+type s3BucketCacheItem struct {
+	Name      string
+	Location  string
+	Timestamp time.Time
+	TTL       time.Duration
+}
+
+type s3ObjectCacheItem struct {
+	Bucket    string
+	Key       string
+	Timestamp time.Time
+	TTL       time.Duration
+}
+
+var s3Buckets = map[string]*s3BucketCacheItem{}
+var s3Objects = map[string]*s3ObjectCacheItem{}
+
+func CacheBucketAdd(name string, location string) *s3BucketCacheItem {
+	bucket := new(s3BucketCacheItem)
+	bucket.Name = name
+	bucket.Location = location
+	bucket.Timestamp = time.Now()
+	bucket.TTL = Options.BucketCacheTTL
+	s3Buckets[name] = bucket
+	return bucket
+}

--- a/S3Proxy/cache.go
+++ b/S3Proxy/cache.go
@@ -2,6 +2,9 @@ package S3Proxy
 
 import "time"
 
+var s3Buckets = map[string]*s3BucketCacheItem{}
+var s3Objects = map[string]*s3ObjectCacheItem{}
+
 type s3BucketCacheItem struct {
 	Name      string
 	Location  string
@@ -9,24 +12,12 @@ type s3BucketCacheItem struct {
 	TTL       time.Duration
 }
 
-type s3ObjectCacheItem struct {
-	Bucket    string
-	Key       string
-	Timestamp time.Time
-	TTL       time.Duration
-}
-
-var s3Buckets = map[string]*s3BucketCacheItem{}
-var s3Objects = map[string]*s3ObjectCacheItem{}
-
-func CacheBucketAdd(name string, location string) *s3BucketCacheItem {
-	bucket := new(s3BucketCacheItem)
-	bucket.Name = name
-	bucket.Location = location
-	bucket.Timestamp = time.Now()
-	bucket.TTL = Options.BucketCacheTTL
-	s3Buckets[name] = bucket
-	return bucket
+func (b s3BucketCacheItem) String() string {
+	return "{Name:" + b.Name +
+		",Location:" + b.Location +
+		",Timestamp:" + b.Timestamp.String() +
+		",TTL:" + (b.TTL - time.Since(b.Timestamp)).String() +
+		"}"
 }
 
 func CacheBucketGet(name string) *s3BucketCacheItem {
@@ -34,9 +25,29 @@ func CacheBucketGet(name string) *s3BucketCacheItem {
 	if hit {
 		// We need to check that the cache entry hasn't expired
 		if time.Since(bucket.Timestamp) <= bucket.TTL {
+			LogInfo("S3 Bucket Cache Hit - " + bucket.String())
 			return bucket
 		}
 	}
 	// We didn't get a cache hit
+	LogInfo("S3 Bucket Cache Miss - {Name:" + name + "}")
 	return nil
+}
+
+func CacheBucketSet(name string, location string) *s3BucketCacheItem {
+	bucket := new(s3BucketCacheItem)
+	bucket.Name = name
+	bucket.Location = location
+	bucket.Timestamp = time.Now()
+	bucket.TTL = Options.BucketCacheTTL
+	s3Buckets[name] = bucket
+	LogInfo("S3 Bucket Cache Set - " + bucket.String())
+	return bucket
+}
+
+type s3ObjectCacheItem struct {
+	Bucket    string
+	Key       string
+	Timestamp time.Time
+	TTL       time.Duration
 }

--- a/S3Proxy/cache.go
+++ b/S3Proxy/cache.go
@@ -28,3 +28,16 @@ func CacheBucketAdd(name string, location string) *s3BucketCacheItem {
 	s3Buckets[name] = bucket
 	return bucket
 }
+
+func CacheBucketGet(name string) *s3BucketCacheItem {
+	bucket, hit := s3Buckets[name]
+	if !hit {
+		// We didn't get a cache hit
+		return nil
+	}
+	// We need to check that the cache entry hasn't expired
+	if time.Since(bucket.Timestamp) <= bucket.TTL {
+		return bucket
+	}
+	return nil
+}

--- a/S3Proxy/cache.go
+++ b/S3Proxy/cache.go
@@ -31,13 +31,12 @@ func CacheBucketAdd(name string, location string) *s3BucketCacheItem {
 
 func CacheBucketGet(name string) *s3BucketCacheItem {
 	bucket, hit := s3Buckets[name]
-	if !hit {
-		// We didn't get a cache hit
-		return nil
+	if hit {
+		// We need to check that the cache entry hasn't expired
+		if time.Since(bucket.Timestamp) <= bucket.TTL {
+			return bucket
+		}
 	}
-	// We need to check that the cache entry hasn't expired
-	if time.Since(bucket.Timestamp) <= bucket.TTL {
-		return bucket
-	}
+	// We didn't get a cache hit
 	return nil
 }

--- a/S3Proxy/cache_test.go
+++ b/S3Proxy/cache_test.go
@@ -7,7 +7,9 @@ import (
 
 func TestCacheBucketGet(t *testing.T) {
 	//Needed for Options.BucketCacheTTL
-	LoadTestOptions()
+	LoadDefaultOptions()
+	// Lower the TTL for testing purposes
+	Options.BucketCacheTTL = time.Duration(2 * time.Second)
 	// Enter a bucket item into the cache
 	CacheBucketSet("test_add", "eu-west-1")
 	// Retrieve the bucket item from the cache
@@ -39,7 +41,9 @@ func TestCacheBucketGet(t *testing.T) {
 
 func TestCacheBucketExpire(t *testing.T) {
 	//Needed for Options.BucketCacheTTL
-	LoadTestOptions()
+	LoadDefaultOptions()
+	// Lower the TTL for testing purposes
+	Options.BucketCacheTTL = time.Duration(2 * time.Second)
 	// Enter a bucket item into the cache
 	CacheBucketSet("test_expire", "eu-west-1")
 	// Sleep long enough for the entry to expire

--- a/S3Proxy/cache_test.go
+++ b/S3Proxy/cache_test.go
@@ -9,7 +9,7 @@ func TestCacheBucketGet(t *testing.T) {
 	//Needed for Options.BucketCacheTTL
 	LoadTestOptions()
 	// Enter a bucket item into the cache
-	CacheBucketAdd("test_add", "eu-west-1")
+	CacheBucketSet("test_add", "eu-west-1")
 	// Retrieve the bucket item from the cache
 	bucket := CacheBucketGet("test_add")
 	// Confirm that the data is valid
@@ -41,7 +41,7 @@ func TestCacheBucketExpire(t *testing.T) {
 	//Needed for Options.BucketCacheTTL
 	LoadTestOptions()
 	// Enter a bucket item into the cache
-	CacheBucketAdd("test_expire", "eu-west-1")
+	CacheBucketSet("test_expire", "eu-west-1")
 	// Sleep long enough for the entry to expire
 	time.Sleep(Options.BucketCacheTTL + time.Second)
 	// Retrieve the bucket item from the cache

--- a/S3Proxy/cache_test.go
+++ b/S3Proxy/cache_test.go
@@ -1,0 +1,58 @@
+package S3Proxy
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCacheBucketGet(t *testing.T) {
+	//Needed for Options.BucketCacheTTL
+	LoadTestOptions()
+	// Enter a bucket item into the cache
+	CacheBucketAdd("test_add", "eu-west-1")
+	// Retrieve the bucket item from the cache
+	bucket := CacheBucketGet("test_add")
+	// Confirm that the data is valid
+	if bucket != nil {
+		if bucket.Name != "test_add" {
+			t.Error(
+				"For", "bucket.Name",
+				"Expected", "test_add",
+				"Got", bucket.Name,
+			)
+		}
+		if bucket.Location != "eu-west-1" {
+			t.Error(
+				"For", "bucket.Location",
+				"Expected", "eu-west-1",
+				"Got", bucket.Location,
+			)
+		}
+	} else {
+		t.Error(
+			"For", "bucket",
+			"Expected", "s3BucketCacheItem",
+			"Got", nil,
+		)
+	}
+}
+
+func TestCacheBucketExpire(t *testing.T) {
+	//Needed for Options.BucketCacheTTL
+	LoadTestOptions()
+	// Enter a bucket item into the cache
+	CacheBucketAdd("test_expire", "eu-west-1")
+	// Sleep long enough for the entry to expire
+	time.Sleep(Options.BucketCacheTTL + time.Second)
+	// Retrieve the bucket item from the cache
+	bucket := CacheBucketGet("test_expire")
+	// Confirm that the entry expired
+	if bucket != nil {
+		t.Error(
+			"For", "CacheBucketGet",
+			"Expected", nil,
+			"Got", bucket,
+		)
+	}
+
+}

--- a/S3Proxy/options.go
+++ b/S3Proxy/options.go
@@ -15,3 +15,10 @@ func LoadDefaultOptions() {
 	Options.BindAddress = ":9090"
 	Options.BucketCacheTTL = time.Duration(1 * time.Hour)
 }
+
+// Options to be loaded in for unit tests
+func LoadTestOptions() {
+	Options.CacheDir = "/tmp/S3Proxy/"
+	Options.BindAddress = ":9090"
+	Options.BucketCacheTTL = time.Duration(2 * time.Second)
+}

--- a/S3Proxy/options.go
+++ b/S3Proxy/options.go
@@ -1,8 +1,11 @@
 package S3Proxy
 
+import "time"
+
 type options struct {
-	CacheDir    string
-	BindAddress string
+	CacheDir       string
+	BindAddress    string
+	BucketCacheTTL time.Duration
 }
 
 var Options = options{}
@@ -10,4 +13,5 @@ var Options = options{}
 func LoadDefaultOptions() {
 	Options.CacheDir = "/tmp/S3Proxy/"
 	Options.BindAddress = ":9090"
+	Options.BucketCacheTTL = time.Duration(1 * time.Hour)
 }

--- a/S3Proxy/options.go
+++ b/S3Proxy/options.go
@@ -15,10 +15,3 @@ func LoadDefaultOptions() {
 	Options.BindAddress = ":9090"
 	Options.BucketCacheTTL = time.Duration(1 * time.Hour)
 }
-
-// Options to be loaded in for unit tests
-func LoadTestOptions() {
-	Options.CacheDir = "/tmp/S3Proxy/"
-	Options.BindAddress = ":9090"
-	Options.BucketCacheTTL = time.Duration(2 * time.Second)
-}

--- a/S3Proxy/s3util.go
+++ b/S3Proxy/s3util.go
@@ -45,7 +45,7 @@ func S3GetBucketLocation(bucket string) (string, *S3ProxyError) {
 	if resp.LocationConstraint != nil {
 		awsRegion = *resp.LocationConstraint
 	}
-
+	CacheBucketAdd(bucket, awsRegion)
 	return awsRegion, nil
 }
 

--- a/S3Proxy/s3util.go
+++ b/S3Proxy/s3util.go
@@ -27,6 +27,11 @@ func handleError(e error) *S3ProxyError {
 }
 
 func S3GetBucketLocation(bucket string) (string, *S3ProxyError) {
+	// Check if we have the bucket cached
+	bucketCacheItem := CacheBucketGet(bucket)
+	if bucketCacheItem != nil {
+		return bucketCacheItem.Location, nil
+	}
 	// Strange behaviour when hitting s3.amazonaws.com. Some regions work fine
 	// other return AuthorizationMalformedHeader. Specifying a region other than
 	// us-east-1 always works.
@@ -45,7 +50,7 @@ func S3GetBucketLocation(bucket string) (string, *S3ProxyError) {
 	if resp.LocationConstraint != nil {
 		awsRegion = *resp.LocationConstraint
 	}
-	CacheBucketAdd(bucket, awsRegion)
+	CacheBucketSet(bucket, awsRegion)
 	return awsRegion, nil
 }
 


### PR DESCRIPTION
This adds caching functionality into S3Proxy for S3 buckets. This allows information about the bucket to be cached so that subsequent requests do not require repetitive calls to S3.

This first implementation reduces the amount of calls to determine the location of the S3 bucket during the TTL of the cache entry.
