### PR TITLE
Get rid of the panic stack trace for the favicon:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: go
 
 go:
-  - tip
+  - 1.4.2
 
 install:
   - go get -v
 
 script: make test
+
+notification:
+  slack:
+    secure: S5wu97HkGqV+byE9fSGOaAL8lidkV2vECLpaumQCD+T4f9AkN3x3Cv6Hcv9KfcbPV7lxM5gwDA8NipjDvd5vK46yVYaO1XoZg04zxGUCK01MjGUagUSXyMhWFd9RuWPQ7iGG5hvjtJPI+q7lkTbRYs4quk5I2GsL9TrRKYpgKbY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script: make test
 notification:
   slack:
     rooms:
-      secure: FjlsKdkPvj50GGzejzcmS6d6JDasz7rQT3uPGP8icMhBIw5a4VfH925Is1APltWM2kanbiecfqEiCwLP9y83Hvk9F5wCvhvkaLJtCKs07aofdlN+oK60bvC6f7VUIKpGKwGKC3XTyZ6jOFiClLXiEixgbrlxb1Cj7eLm+j60Bok=
+      secure: otuIMaw6i8w9n4s7UVczgEYL4oeLdSOMZycjxWyaBzTWQnNkbqOrTz6zYjMPZWeP2HCc99xbVf3t0psaUbZxXOl3AbS0XI06rZiqJI3tVhAWZR5p/+GBjXxboSnOCtzBCPhhCqWQeV3SqIX712ga6wquB0k/evb8y7SXLou+euo=

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ script: make test
 
 notification:
   slack:
-    secure: S5wu97HkGqV+byE9fSGOaAL8lidkV2vECLpaumQCD+T4f9AkN3x3Cv6Hcv9KfcbPV7lxM5gwDA8NipjDvd5vK46yVYaO1XoZg04zxGUCK01MjGUagUSXyMhWFd9RuWPQ7iGG5hvjtJPI+q7lkTbRYs4quk5I2GsL9TrRKYpgKbY=
+    rooms:
+      secure: S5wu97HkGqV+byE9fSGOaAL8lidkV2vECLpaumQCD+T4f9AkN3x3Cv6Hcv9KfcbPV7lxM5gwDA8NipjDvd5vK46yVYaO1XoZg04zxGUCK01MjGUagUSXyMhWFd9RuWPQ7iGG5hvjtJPI+q7lkTbRYs4quk5I2GsL9TrRKYpgKbY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: go
-
 go:
-  - 1.4.2
-
+- 1.4.2
 install:
-  - go get -v
-
+- go get -v
 script: make test
-
 notification:
   slack:
     rooms:
       secure: otuIMaw6i8w9n4s7UVczgEYL4oeLdSOMZycjxWyaBzTWQnNkbqOrTz6zYjMPZWeP2HCc99xbVf3t0psaUbZxXOl3AbS0XI06rZiqJI3tVhAWZR5p/+GBjXxboSnOCtzBCPhhCqWQeV3SqIX712ga6wquB0k/evb8y7SXLou+euo=
+notifications:
+  slack:
+    rooms:
+      secure: BTGF1SHSRHP+I82V1t86tRrYYaFVs5ZaxLaB/xQkB/nkYjJ14isAxz5s1oIS1sTorhLIBWtHgo8OecJ2tOIKv/t/yY5dckr5nl+KDUzQ+hdQ9pBAKUkH9mYgRGyH+L9gSaprf6YfQK7/rlrAV2qx7xvjVwXO4GR+41nldSmK86A=

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script: make test
 notification:
   slack:
     rooms:
-      secure: S5wu97HkGqV+byE9fSGOaAL8lidkV2vECLpaumQCD+T4f9AkN3x3Cv6Hcv9KfcbPV7lxM5gwDA8NipjDvd5vK46yVYaO1XoZg04zxGUCK01MjGUagUSXyMhWFd9RuWPQ7iGG5hvjtJPI+q7lkTbRYs4quk5I2GsL9TrRKYpgKbY=
+      secure: FjlsKdkPvj50GGzejzcmS6d6JDasz7rQT3uPGP8icMhBIw5a4VfH925Is1APltWM2kanbiecfqEiCwLP9y83Hvk9F5wCvhvkaLJtCKs07aofdlN+oK60bvC6f7VUIKpGKwGKC3XTyZ6jOFiClLXiEixgbrlxb1Cj7eLm+j60Bok=

--- a/S3Proxy/handlers.go
+++ b/S3Proxy/handlers.go
@@ -13,6 +13,11 @@ func IndexHandler(w http.ResponseWriter, req *http.Request) {
 	return
 }
 
+// FaviconHandler
+func FaviconHandler(w http.ResponseWriter, req *http.Request) {
+	http.Error(w, "", 404)
+}
+
 // The status handler for determining the status of the server
 func StatusHandler(w http.ResponseWriter, req *http.Request) {
 	panic("Not Implemented")

--- a/S3Proxy/routing.go
+++ b/S3Proxy/routing.go
@@ -7,6 +7,8 @@ func SetUpRoutes() *routes.RouteMux {
 	mux := routes.New()
 	// Route: Index
 	mux.Get("/", IndexHandler)
+	// Route: Favicon
+	mux.Get("/favicon.ico", FaviconHandler)
 	// Route: Status
 	mux.Get("/_status", StatusHandler)
 	// Route: Default


### PR DESCRIPTION
If you use a browser to download content from S3Proxy, it results in a
panic stack trace in the S3Proxy server logs. This is caused by Chrome
(possibly others) doing a subsequent request to get the favicon
(/favicon.ico).

Because of the catch-all nature of the regex, S3Proxy tries to lookup a
bucket with that name.

The simple fix is to 404 on the favicon URL
