### PR TITLE
Get rid of the panic stack trace for the favicon:

### DIFF
--- a/S3Proxy/handlers.go
+++ b/S3Proxy/handlers.go
@@ -13,6 +13,11 @@ func IndexHandler(w http.ResponseWriter, req *http.Request) {
 	return
 }
 
+// FaviconHandler
+func FaviconHandler(w http.ResponseWriter, req *http.Request) {
+	http.Error(w, "", 404)
+}
+
 // The status handler for determining the status of the server
 func StatusHandler(w http.ResponseWriter, req *http.Request) {
 	panic("Not Implemented")

--- a/S3Proxy/routing.go
+++ b/S3Proxy/routing.go
@@ -7,6 +7,8 @@ func SetUpRoutes() *routes.RouteMux {
 	mux := routes.New()
 	// Route: Index
 	mux.Get("/", IndexHandler)
+	// Route: Favicon
+	mux.Get("/favicon.ico", FaviconHandler)
 	// Route: Status
 	mux.Get("/_status", StatusHandler)
 	// Route: Default


### PR DESCRIPTION
If you use a browser to download content from S3Proxy, it results in a
panic stack trace in the S3Proxy server logs. This is caused by Chrome
(possibly others) doing a subsequent request to get the favicon
(/favicon.ico).

Because of the catch-all nature of the regex, S3Proxy tries to lookup a
bucket with that name.

The simple fix is to 404 on the favicon URL
